### PR TITLE
Initial implementation of a very simple LRU cache.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package lru_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/lru"
+)
+
+type BenchmarkSuite struct{}
+
+var _ = gc.Suite(&BenchmarkSuite{})
+
+func (*BenchmarkSuite) BenchmarkAddAndEvict1000(c *gc.C) {
+	cache := lru.New(1000)
+	for i := 0; i < c.N; i++ {
+		cache.Add(i, i)
+	}
+	expectLen := 1000
+	if c.N < expectLen {
+		expectLen = c.N
+	}
+	c.Assert(cache.Len(), gc.Equals, expectLen)
+}

--- a/lru.go
+++ b/lru.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// LRU implements a least-recently-used cache, which tracks what items have been accessed,
+// and evicts them when adding a new item if it hasn't been used recently.
+package lru
+
+import (
+	"container/list"
+)
+
+// LRU implements a least-recently-used cache, evicting items from the cache if they have not been accessed in a while.
+type LRU struct {
+	maxSize int
+	keys    *list.List
+	values  map[interface{}]cacheEntry
+}
+
+type cacheEntry struct {
+	listElem *list.Element
+	value    interface{}
+}
+
+// Create a new LRU cache that will hold no more than the given number of items,
+func New(size int) *LRU {
+	return &LRU{
+		maxSize: size,
+		keys:    list.New(),
+		values:  make(map[interface{}]cacheEntry, 0),
+	}
+}
+
+// Len gives the number of items in the cache
+func (lru *LRU) Len() int {
+	return len(lru.values)
+}
+
+// Add a new entry into the LRU cache
+func (lru *LRU) Add(key, value interface{}) {
+	entry, exists := lru.values[key]
+	if exists {
+		lru.keys.MoveToFront(entry.listElem)
+		// Update the value
+		entry.value = value
+	} else {
+		// We are adding an element, make sure there is room
+		if lru.keys.Len() >= lru.maxSize {
+			lru.removeLast()
+		}
+		elem := lru.keys.PushFront(key)
+		entry = cacheEntry{
+			listElem: elem,
+			value:    value,
+		}
+	}
+	lru.values[key] = entry
+}
+
+// Get returns the Value associated with key, and a boolean as to whether it actually exists in the cache.
+// If it does exist in the cache, then it is treated as recently accessed.
+func (lru *LRU) Get(key interface{}) (interface{}, bool) {
+	entry, exists := lru.values[key]
+	if exists {
+		lru.keys.MoveToFront(entry.listElem)
+		return entry.value, true
+	} else {
+		return nil, false
+	}
+}
+
+// Peek is just like Get() except it doesn't affect if it was 'recently accessed'
+func (lru *LRU) Peek(key interface{}) (interface{}, bool) {
+	if entry, exists := lru.values[key]; exists {
+		return entry.value, true
+	}
+	return nil, false
+}
+
+// removeLast removes the oldest entry from the queue
+func (lru *LRU) removeLast() {
+	last := lru.keys.Back()
+	if last != nil {
+		lru.keys.Remove(last)
+	}
+	// remember the "Value" in the list is actually a key
+	delete(lru.values, last.Value)
+}

--- a/lru_test.go
+++ b/lru_test.go
@@ -1,0 +1,123 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package lru_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/lru"
+)
+
+func TestAll(t *testing.T) {
+	// Pass nil for Certs because we don't need SSL
+	gc.TestingT(t)
+}
+
+type LRUSuite struct{}
+
+var _ = gc.Suite(&LRUSuite{})
+
+func checkPeekExists(c *gc.C, cache *lru.LRU, key, value interface{}) {
+	checkedValue, checkedExists := cache.Peek(key)
+	c.Check(checkedExists, gc.Equals, true,
+		gc.Commentf("key %#v did not exist in cache", key))
+	if checkedExists {
+		c.Check(checkedValue, gc.Equals, value)
+	}
+}
+
+func checkPeekMissing(c *gc.C, cache *lru.LRU, key interface{}) {
+	checkedValue, checkedExists := cache.Peek(key)
+	c.Check(checkedExists, gc.Equals, false,
+		gc.Commentf("key %#v shouldn't have been present in cache with value %v", key, checkedValue))
+}
+
+func checkGet(c *gc.C, cache *lru.LRU, key, value interface{}, exists bool) {
+	checkedValue, checkedExists := cache.Get(key)
+	c.Check(checkedValue, gc.Equals, value)
+	c.Check(checkedExists, gc.Equals, exists)
+}
+
+func simpleFullCache() *lru.LRU {
+	cache := lru.New(10)
+	cache.Add(1, "a")
+	cache.Add(2, "b")
+	cache.Add(3, "c")
+	cache.Add(4, "d")
+	cache.Add(5, "e")
+	cache.Add(6, "f")
+	cache.Add(7, "g")
+	cache.Add(8, "h")
+	cache.Add(9, "i")
+	cache.Add(0, "j")
+	return cache
+}
+
+func (s *LRUSuite) TestLRUAdd(c *gc.C) {
+	cache := lru.New(128)
+	cache.Add("foo", "bar")
+	checkPeekExists(c, cache, "foo", "bar")
+	checkPeekMissing(c, cache, "bar")
+}
+
+func (s *LRUSuite) TestLRUAddReplaces(c *gc.C) {
+	cache := simpleFullCache()
+	cache.Add(1, "bar")
+	checkPeekExists(c, cache, 1, "bar")
+}
+
+func (s *LRUSuite) TestLRUAddEvicts(c *gc.C) {
+	cache := simpleFullCache()
+	cache.Add("a", "k")
+	// 1 being the least recent, should be evicted
+	checkPeekMissing(c, cache, 1)
+	checkPeekExists(c, cache, 2, "b")
+	checkPeekExists(c, cache, 3, "c")
+	checkPeekExists(c, cache, 4, "d")
+	checkPeekExists(c, cache, 5, "e")
+	checkPeekExists(c, cache, 6, "f")
+	checkPeekExists(c, cache, 7, "g")
+	checkPeekExists(c, cache, 8, "h")
+	checkPeekExists(c, cache, 9, "i")
+	checkPeekExists(c, cache, 0, "j")
+	checkPeekExists(c, cache, "a", "k")
+}
+
+func (s *LRUSuite) TestLRUGetNoExists(c *gc.C) {
+	cache := simpleFullCache()
+	checkGet(c, cache, "nope", nil, false)
+}
+
+func (s *LRUSuite) TestLRUGetUpdatesEvict(c *gc.C) {
+	cache := simpleFullCache()
+	checkGet(c, cache, 1, "a", true)
+	checkGet(c, cache, 2, "b", true)
+	// Add a value, which should evict 3, because 1 and 2 have been accessed
+	cache.Add("q", "blah")
+	checkPeekExists(c, cache, 1, "a")
+	checkPeekExists(c, cache, 2, "b")
+	checkPeekMissing(c, cache, 3)
+	checkPeekExists(c, cache, 4, "d")
+	checkPeekExists(c, cache, 5, "e")
+	checkPeekExists(c, cache, 6, "f")
+	checkPeekExists(c, cache, 7, "g")
+	checkPeekExists(c, cache, 8, "h")
+	checkPeekExists(c, cache, 9, "i")
+	checkPeekExists(c, cache, 0, "j")
+	checkPeekExists(c, cache, "q", "blah")
+}
+
+func (s *LRUSuite) TestLRULen(c *gc.C) {
+	cache := lru.New(20)
+	for i := 1; i <= 25; i++ {
+		cache.Add(i, i)
+		if i < 20 {
+			c.Check(cache.Len(), gc.Equals, i)
+		} else {
+			c.Check(cache.Len(), gc.Equals, 20)
+		}
+	}
+}


### PR DESCRIPTION
There are other implementations that exist, but the algorithm is simple enough that it
avoids any issues with copyright. It also gives an opportunity to play
with cache efficiencies. (Is it better to just put keys into the
container/list.List, or is it better to hold full entries.)

We also have 100% code coverage, though testing is pretty trivial.
