### PR TITLE
StringCache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ check-licence:
 		xargs -I {} echo FAIL: licence missed: {}
 
 check-go:
-	$(eval GOFMT := $(strip $(shell gofmt -l .| sed -e "s/^/ /g")))
+	$(eval GOFMT := $(strip $(shell gofmt -l -s .| sed -e "s/^/ /g")))
 	@(if [ "x$(GOFMT)" != "x" ]; then \
 		echo "go fmt is sad: $(GOFMT)"; \
 		exit 1; \

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,6 +4,7 @@
 package lru_test
 
 import (
+	"fmt"
 	"math/rand"
 
 	gc "gopkg.in/check.v1"
@@ -15,67 +16,104 @@ type BenchmarkSuite struct{}
 
 var _ = gc.Suite(&BenchmarkSuite{})
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0000100(c *gc.C) {
-	benchAddAndEvict(c, 100)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000010(c *gc.C) {
+	benchAddAndEvictInt(c, 10)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0000200(c *gc.C) {
-	benchAddAndEvict(c, 200)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000020(c *gc.C) {
+	benchAddAndEvictInt(c, 20)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0000500(c *gc.C) {
-	benchAddAndEvict(c, 500)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000050(c *gc.C) {
+	benchAddAndEvictInt(c, 50)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0001000(c *gc.C) {
-	benchAddAndEvict(c, 1000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000100(c *gc.C) {
+	benchAddAndEvictInt(c, 100)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0002000(c *gc.C) {
-	benchAddAndEvict(c, 2000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000200(c *gc.C) {
+	benchAddAndEvictInt(c, 200)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0005000(c *gc.C) {
-	benchAddAndEvict(c, 5000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000500(c *gc.C) {
+	benchAddAndEvictInt(c, 500)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0010000(c *gc.C) {
-	benchAddAndEvict(c, 10000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0001000(c *gc.C) {
+	benchAddAndEvictInt(c, 1000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0020000(c *gc.C) {
-	benchAddAndEvict(c, 20000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0002000(c *gc.C) {
+	benchAddAndEvictInt(c, 2000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0050000(c *gc.C) {
-	benchAddAndEvict(c, 50000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0005000(c *gc.C) {
+	benchAddAndEvictInt(c, 5000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0100000(c *gc.C) {
-	benchAddAndEvict(c, 100000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0010000(c *gc.C) {
+	benchAddAndEvictInt(c, 10000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0200000(c *gc.C) {
-	benchAddAndEvict(c, 200000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0020000(c *gc.C) {
+	benchAddAndEvictInt(c, 20000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict0500000(c *gc.C) {
-	benchAddAndEvict(c, 500000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0050000(c *gc.C) {
+	benchAddAndEvictInt(c, 50000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict1000000(c *gc.C) {
-	benchAddAndEvict(c, 1000000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0100000(c *gc.C) {
+	benchAddAndEvictInt(c, 100000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvict2000000(c *gc.C) {
-	benchAddAndEvict(c, 2000000)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0200000(c *gc.C) {
+	benchAddAndEvictInt(c, 200000)
 }
 
-func benchAddAndEvict(c *gc.C, size int) {
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt0500000(c *gc.C) {
+	benchAddAndEvictInt(c, 500000)
+}
 
-	cache := lru.New(size)
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt1000000(c *gc.C) {
+	benchAddAndEvictInt(c, 1000000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictInt2000000(c *gc.C) {
+	benchAddAndEvictInt(c, 2000000)
+}
+
+func (*BenchmarkSuite) BenchmarkIntMemSize(c *gc.C) {
+	cache := lru.New(c.N)
 	for i := 0; i < c.N; i++ {
 		cache.Add(i, i)
+	}
+}
+
+func (*BenchmarkSuite) BenchmarkStrMemSize(c *gc.C) {
+	keys := make([]string, c.N)
+	for i := 0; i < c.N; i++ {
+		keys[i] = fmt.Sprint(i + 1e7)
+	}
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
+	c.ResetTimer()
+	cache := lru.New(c.N)
+	for i := 0; i < c.N; i++ {
+		cache.Add(keys[i], i)
+	}
+}
+
+func benchAddAndEvictInt(c *gc.C, size int) {
+	keys := make([]int, c.N)
+	for i := 0; i < c.N; i++ {
+		keys[i] = i + 1e7
+	}
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
+	cache := lru.New(size)
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		cache.Add(keys[i], i)
 	}
 	expectLen := size
 	if c.N < expectLen {
@@ -152,10 +190,6 @@ func (*BenchmarkSuite) BenchmarkGet2000000(c *gc.C) {
 	benchGet(c, 2000000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet5000000(c *gc.C) {
-	benchGet(c, 5000000)
-}
-
 func benchGet(c *gc.C, size int) {
 	cache := lru.New(size)
 	lookups := make([]int, size)
@@ -169,4 +203,91 @@ func benchGet(c *gc.C, size int) {
 	for i := 0; i < c.N; i++ {
 		cache.Get(lookups[i%size])
 	}
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000010(c *gc.C) {
+	benchAddAndEvictStr(c, 10)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000020(c *gc.C) {
+	benchAddAndEvictStr(c, 20)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000050(c *gc.C) {
+	benchAddAndEvictStr(c, 50)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000100(c *gc.C) {
+	benchAddAndEvictStr(c, 100)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000200(c *gc.C) {
+	benchAddAndEvictStr(c, 200)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000500(c *gc.C) {
+	benchAddAndEvictStr(c, 500)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0001000(c *gc.C) {
+	benchAddAndEvictStr(c, 1000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0002000(c *gc.C) {
+	benchAddAndEvictStr(c, 2000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0005000(c *gc.C) {
+	benchAddAndEvictStr(c, 5000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0010000(c *gc.C) {
+	benchAddAndEvictStr(c, 10000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0020000(c *gc.C) {
+	benchAddAndEvictStr(c, 20000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0050000(c *gc.C) {
+	benchAddAndEvictStr(c, 50000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0100000(c *gc.C) {
+	benchAddAndEvictStr(c, 100000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0200000(c *gc.C) {
+	benchAddAndEvictStr(c, 200000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr0500000(c *gc.C) {
+	benchAddAndEvictStr(c, 500000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr1000000(c *gc.C) {
+	benchAddAndEvictStr(c, 1000000)
+}
+
+func (*BenchmarkSuite) BenchmarkAddAndEvictStr2000000(c *gc.C) {
+	benchAddAndEvictStr(c, 2000000)
+}
+
+func benchAddAndEvictStr(c *gc.C, size int) {
+	keys := make([]string, c.N)
+	for i := 0; i < c.N; i++ {
+		keys[i] = fmt.Sprint(i + 1e7)
+	}
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
+	cache := lru.New(size)
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		cache.Add(keys[i], i)
+	}
+	expectLen := size
+	if c.N < expectLen {
+		expectLen = c.N
+	}
+	c.Assert(cache.Len(), gc.Equals, expectLen)
+
 }

--- a/strings.go
+++ b/strings.go
@@ -1,0 +1,141 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package lru
+
+import (
+	"fmt"
+)
+
+type stringElem struct {
+	value      string
+	prev, next *stringElem
+}
+
+// StringCache tracks a limited number of strings.
+// Use Intern() to get a saved version of the string, such that
+//   x := cache.Intern(s1)
+//   y := cache.Intern(s2)
+// Now x and y will use the same underlying memory if s1 == s2.
+type StringCache struct {
+	maxSize int
+	root    stringElem
+	len     int
+	values  map[string]*stringElem
+}
+
+func NewStringCache(size int) *StringCache {
+	cache := &StringCache{
+		maxSize: size,
+	}
+	cache.init()
+	return cache
+}
+
+func (sc *StringCache) init() {
+	sc.values = make(map[string]*stringElem, sc.maxSize)
+	sc.root.prev = &sc.root
+	sc.root.next = &sc.root
+	sc.len = 0
+}
+
+// Len returns how many strings are currently cached
+func (sc *StringCache) Len() int {
+	return sc.len
+}
+
+// realloc creates a slice of memory, and puts everything in order and simplifies the pointers.
+// this allocates into a single slab of memory, instead of being scattered around everywhere
+func (sc *StringCache) realloc() {
+	buff := make([]stringElem, sc.maxSize)
+	cur := sc.root.next
+	for i := 0; i < sc.maxSize; i++ {
+		buff[i].value = cur.value
+		if i > 0 {
+			buff[i].prev = &buff[i-1]
+		}
+		if i < sc.maxSize-1 {
+			buff[i].next = &buff[i+1]
+		}
+		sc.values[cur.value] = &buff[i]
+		cur = cur.next
+	}
+	sc.root.next = &buff[0]
+	sc.root.prev = &buff[sc.maxSize-1]
+	buff[0].prev = &sc.root
+	buff[sc.maxSize-1].next = &sc.root
+}
+
+func (sc *StringCache) Validate() error {
+	count := 0
+	for cur := sc.root.next; cur != &sc.root; cur = cur.next {
+		count++
+		if cur.prev.next != cur {
+			return fmt.Errorf("error at %#v, the value after prev is not this", cur)
+		}
+		if cur.next.prev != cur {
+			return fmt.Errorf("error at %#v, the value before next is not this", cur)
+		}
+		v := cur.value
+		if sc.values[v] != cur {
+			return fmt.Errorf("error at %q, %p %# v, the map doesn't point to cur it points to: %p %# v",
+				v, cur, cur, sc.values[v], sc.values[v])
+		}
+	}
+	if count != sc.len {
+		return fmt.Errorf("incorrect count, expected %d got %d", sc.len, count)
+	}
+	if len(sc.values) != sc.len {
+		return fmt.Errorf("value map has wrong count, expected %d got %d", sc.len, len(sc.values))
+	}
+	return nil
+}
+
+// Intern takes a string, and returns either the cached copy of the string, or caches the string and returns it back.
+// It also updates how recently the string was seen, so that strings aren't cached forever.
+func (sc *StringCache) Intern(v string) string {
+	if elem, ok := sc.values[v]; ok {
+		sc.moveToFront(elem)
+		return elem.value
+	}
+	var elem *stringElem
+	if sc.len < sc.maxSize {
+		elem = &stringElem{value: v}
+		sc.len++
+		if sc.len == sc.maxSize {
+			sc.moveToFront(elem)
+			sc.realloc()
+			return v
+		}
+	} else {
+		elem = sc.root.prev
+		delete(sc.values, elem.value)
+		elem.value = v
+	}
+	sc.moveToFront(elem)
+	sc.values[v] = elem
+	return v
+}
+
+// Contains returns true if the string is in the cache. It does not change information about recently-used.
+func (sc *StringCache) Contains(v string) bool {
+	_, ok := sc.values[v]
+	return ok
+}
+
+func (sc *StringCache) moveToFront(elem *stringElem) {
+	if sc.root.next == elem {
+		// we're already at the front
+		return
+	}
+	if elem.prev != nil {
+		// remove it from its current spot
+		elem.prev.next = elem.next
+		elem.next.prev = elem.prev
+	}
+	next := sc.root.next
+	sc.root.next = elem
+	elem.prev = &sc.root
+	elem.next = next
+	next.prev = elem
+}

--- a/strings_test.go
+++ b/strings_test.go
@@ -1,0 +1,262 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package lru_test
+
+import (
+	"fmt"
+	"math/rand"
+	"unsafe"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/lru"
+)
+
+type StringsSuite struct{}
+
+// this is taken from runtime/string.go
+type stringStruct struct {
+	str unsafe.Pointer
+	len int
+}
+
+var _ = gc.Suite(&StringsSuite{})
+
+func isSameStr(s1, s2 string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	ss1 := *(*stringStruct)(unsafe.Pointer(&s1))
+	ss2 := *(*stringStruct)(unsafe.Pointer(&s2))
+	return ss1.str == ss2.str
+}
+
+func (*StringsSuite) TestIntern(c *gc.C) {
+	str1 := fmt.Sprintf("foo%s", "bar")
+	str2 := fmt.Sprintf("foo%s", "bar")
+	c.Check(isSameStr(str1, str2), gc.Equals, false)
+
+	cache := lru.NewStringCache(100)
+	str3 := cache.Intern(str1)
+	c.Check(isSameStr(str1, str3), gc.Equals, true)
+	str4 := cache.Intern(str2)
+	c.Check(isSameStr(str1, str4), gc.Equals, true)
+	c.Check(cache.Len(), gc.Equals, 1)
+	c.Check(cache.Contains(str1), gc.Equals, true)
+}
+
+func (*StringsSuite) TestInternMaxSize(c *gc.C) {
+	cache := lru.NewStringCache(5)
+	for i := 0; i < 30; i++ {
+		s := fmt.Sprint(i)
+		res := cache.Intern(s)
+		c.Check(res, gc.Equals, s)
+		c.Check(isSameStr(s, res), gc.Equals, true)
+		c.Check(cache.Contains(fmt.Sprint(i)), gc.Equals, true,
+			gc.Commentf("%d should immediately be cached", i))
+		err := cache.Validate()
+		c.Assert(err, gc.IsNil, gc.Commentf("Validate adding %d failed with: %s", i, err))
+	}
+	c.Check(cache.Len(), gc.Equals, 5)
+	for i := 0; i < 25; i++ {
+		c.Check(cache.Contains(fmt.Sprint(i)), gc.Equals, false,
+			gc.Commentf("%d was not supposed to be cached", i))
+	}
+	for i := 25; i < 30; i++ {
+		c.Check(cache.Contains(fmt.Sprint(i)), gc.Equals, true,
+			gc.Commentf("%d was supposed to be cached", i))
+	}
+}
+
+func (*StringsSuite) TestInternAbuse(c *gc.C) {
+	const totalKeys = 100000
+	const totalUniqueKeys = 1000
+	keys := make([]string, totalKeys)
+	for i := 0; i < totalKeys; i++ {
+		keys[i] = fmt.Sprint((i % totalUniqueKeys) + 1000000)
+	}
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
+	var size int = totalUniqueKeys * 0.75
+	c.Logf("using size: %d", size)
+	cache := lru.NewStringCache(size)
+	for _, k := range keys {
+		v := cache.Intern(k)
+		c.Assert(v, gc.Equals, k)
+	}
+	c.Check(cache.Len(), gc.Equals, size)
+}
+
+var _ = gc.Suite(&BenchmarkStrings{})
+
+type BenchmarkStrings struct{}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000010(c *gc.C) {
+	benchmarkIntern(c, 10, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000020(c *gc.C) {
+	benchmarkIntern(c, 20, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000050(c *gc.C) {
+	benchmarkIntern(c, 50, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000100(c *gc.C) {
+	benchmarkIntern(c, 100, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000200(c *gc.C) {
+	benchmarkIntern(c, 200, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0000500(c *gc.C) {
+	benchmarkIntern(c, 500, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0001000(c *gc.C) {
+	benchmarkIntern(c, 1000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0002000(c *gc.C) {
+	benchmarkIntern(c, 2000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0005000(c *gc.C) {
+	benchmarkIntern(c, 5000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0010000(c *gc.C) {
+	benchmarkIntern(c, 10000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0020000(c *gc.C) {
+	benchmarkIntern(c, 20000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0050000(c *gc.C) {
+	benchmarkIntern(c, 50000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0100000(c *gc.C) {
+	benchmarkIntern(c, 100000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0200000(c *gc.C) {
+	benchmarkIntern(c, 200000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand0500000(c *gc.C) {
+	benchmarkIntern(c, 500000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand1000000(c *gc.C) {
+	benchmarkIntern(c, 1000000, true)
+}
+
+func (*BenchmarkStrings) BenchmarkInternRand2000000(c *gc.C) {
+	benchmarkIntern(c, 2000000, true)
+}
+
+func benchmarkIntern(c *gc.C, size int, randomize bool) {
+	strs := make([]string, c.N)
+	for i := 0; i < c.N; i++ {
+		// We want reasonably long strings
+		strs[i] = fmt.Sprint(i + 10000000)
+	}
+	if randomize {
+		rand.Shuffle(c.N, func(i, j int) { strs[j], strs[i] = strs[i], strs[j] })
+	}
+	cache := lru.NewStringCache(size)
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		cache.Intern(strs[i])
+	}
+	expectLen := size
+	if c.N < expectLen {
+		expectLen = c.N
+	}
+	c.Assert(cache.Len(), gc.Equals, expectLen)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000010(c *gc.C) {
+	benchmarkIntern(c, 10, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000020(c *gc.C) {
+	benchmarkIntern(c, 20, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000050(c *gc.C) {
+	benchmarkIntern(c, 50, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000100(c *gc.C) {
+	benchmarkIntern(c, 100, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000200(c *gc.C) {
+	benchmarkIntern(c, 200, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0000500(c *gc.C) {
+	benchmarkIntern(c, 500, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0001000(c *gc.C) {
+	benchmarkIntern(c, 1000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0002000(c *gc.C) {
+	benchmarkIntern(c, 2000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0005000(c *gc.C) {
+	benchmarkIntern(c, 5000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0010000(c *gc.C) {
+	benchmarkIntern(c, 10000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0020000(c *gc.C) {
+	benchmarkIntern(c, 20000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0050000(c *gc.C) {
+	benchmarkIntern(c, 50000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0100000(c *gc.C) {
+	benchmarkIntern(c, 100000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0200000(c *gc.C) {
+	benchmarkIntern(c, 200000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern0500000(c *gc.C) {
+	benchmarkIntern(c, 500000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern1000000(c *gc.C) {
+	benchmarkIntern(c, 1000000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkIntern2000000(c *gc.C) {
+	benchmarkIntern(c, 2000000, false)
+}
+
+func (*BenchmarkStrings) BenchmarkInternMemSize(c *gc.C) {
+	keys := make([]string, c.N)
+	for i := 0; i < c.N; i++ {
+		keys[i] = fmt.Sprint(i + 1e7)
+	}
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
+	c.ResetTimer()
+	cache := lru.NewStringCache(c.N)
+	for i := 0; i < c.N; i++ {
+		cache.Intern(keys[i])
+	}
+}


### PR DESCRIPTION
This brings an optimized version for caching strings.

a) It avoids an Add() + Get() step. Instead it just has Intern() which gets if exists, and adds otherwise.
b) It uses more optimized types. We don't need a full list.List implementation, we only need 'moveToFront'. It allows us to do 0 allocations once we fill the cache, we only change the pointers to what data is stored.

This also adds a lot of benchmarks around the various activities.