### PR TITLE
Add hit/miss counting, but not mutex for thread safety.

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -7,23 +7,27 @@ import (
 	"fmt"
 )
 
-type stringElem struct {
-	value      string
-	prev, next *stringElem
-}
-
 // StringCache tracks a limited number of strings.
 // Use Intern() to get a saved version of the string, such that
 //   x := cache.Intern(s1)
 //   y := cache.Intern(s2)
 // Now x and y will use the same underlying memory if s1 == s2.
+// We track a map into a doubly linked list, moving accessed (or recently
+// added) strings to the front of the list, and using the expiry at the end of
+// the list to maintain the size of the cache.
+// Note that StringCache is *not* thread safe, some form of mutex is necessary
+// if you want to access it from multiple threads.
 type StringCache struct {
-	maxSize int
-	root    stringElem
-	len     int
-	values  map[string]*stringElem
+	maxSize   int
+	size      int
+	hitCount  int64
+	missCount int64
+	root      stringElem
+	values    map[string]*stringElem
 }
 
+// NewStringCache creates a cache for string objects that will hold no-more
+// than 'size' strings.
 func NewStringCache(size int) *StringCache {
 	cache := &StringCache{
 		maxSize: size,
@@ -32,20 +36,49 @@ func NewStringCache(size int) *StringCache {
 	return cache
 }
 
+// stringElem represents a doubly linked list of elements, which allows us to
+// move an entry from anywhere in the list to the 'front' of the list whenever
+// it is accessed.
+// For a complete double-linked list implementation, see the golang standard
+// library "container/list". However, by inlining some of the functionality,
+// we are able to save on storage size, and remove levels of indirection.
+// The only function we need is 'MoveToFront', as we also never remove items,
+// instead replacing the content when the old value is expired.
+type stringElem struct {
+	value      string
+	prev, next *stringElem
+}
+
 func (sc *StringCache) init() {
 	sc.values = make(map[string]*stringElem, sc.maxSize)
 	sc.root.prev = &sc.root
 	sc.root.next = &sc.root
-	sc.len = 0
+	sc.size = 0
 }
 
 // Len returns how many strings are currently cached
 func (sc *StringCache) Len() int {
-	return sc.len
+	return sc.size
 }
 
-// realloc creates a slice of memory, and puts everything in order and simplifies the pointers.
-// this allocates into a single slab of memory, instead of being scattered around everywhere
+// HitCounts is used to track how well this cache is working
+type HitCounts struct {
+	Hit, Miss int64
+}
+
+// HitCounts gives information about accesses to the cache. The total number of
+// calls to Intern can be computed by adding Hit and Miss.
+func (sc *StringCache) HitCounts() HitCounts {
+	return HitCounts{
+		Hit:  sc.hitCount,
+		Miss: sc.missCount,
+	}
+}
+
+// realloc creates a slice of memory, and puts everything in order and
+// simplifies the pointers.  This allocates into a single slab of memory,
+// instead of being scattered around everywhere. We call this once our cache is
+// full, and we know we won't be allocating any more elements.
 func (sc *StringCache) realloc() {
 	buff := make([]stringElem, sc.maxSize)
 	cur := sc.root.next
@@ -66,6 +99,8 @@ func (sc *StringCache) realloc() {
 	buff[sc.maxSize-1].next = &sc.root
 }
 
+// Validate checks invariants to make sure the double-linked list is properly
+// linked, and that the values map to the correct element.
 func (sc *StringCache) Validate() error {
 	count := 0
 	for cur := sc.root.next; cur != &sc.root; cur = cur.next {
@@ -82,27 +117,31 @@ func (sc *StringCache) Validate() error {
 				v, cur, cur, sc.values[v], sc.values[v])
 		}
 	}
-	if count != sc.len {
-		return fmt.Errorf("incorrect count, expected %d got %d", sc.len, count)
+	if count != sc.size {
+		return fmt.Errorf("incorrect count, expected %d got %d", sc.size, count)
 	}
-	if len(sc.values) != sc.len {
-		return fmt.Errorf("value map has wrong count, expected %d got %d", sc.len, len(sc.values))
+	if len(sc.values) != sc.size {
+		return fmt.Errorf("value map has wrong count, expected %d got %d", sc.size, len(sc.values))
 	}
 	return nil
 }
 
-// Intern takes a string, and returns either the cached copy of the string, or caches the string and returns it back.
-// It also updates how recently the string was seen, so that strings aren't cached forever.
+// Intern takes a string, and returns either the cached copy of the string, or
+// caches the string and returns it back.  It also updates how recently the
+// string was seen, so that strings aren't cached forever.
 func (sc *StringCache) Intern(v string) string {
 	if elem, ok := sc.values[v]; ok {
 		sc.moveToFront(elem)
-		return elem.value
+		v := elem.value
+		sc.hitCount++
+		return v
 	}
+	sc.missCount++
 	var elem *stringElem
-	if sc.len < sc.maxSize {
+	if sc.size < sc.maxSize {
 		elem = &stringElem{value: v}
-		sc.len++
-		if sc.len == sc.maxSize {
+		sc.size++
+		if sc.size == sc.maxSize {
 			sc.moveToFront(elem)
 			sc.realloc()
 			return v
@@ -117,7 +156,8 @@ func (sc *StringCache) Intern(v string) string {
 	return v
 }
 
-// Contains returns true if the string is in the cache. It does not change information about recently-used.
+// Contains returns true if the string is in the cache. It does not change
+// information about recently-used.
 func (sc *StringCache) Contains(v string) bool {
 	_, ok := sc.values[v]
 	return ok

--- a/strings_test.go
+++ b/strings_test.go
@@ -88,6 +88,23 @@ func (*StringsSuite) TestInternAbuse(c *gc.C) {
 	c.Check(cache.Len(), gc.Equals, size)
 }
 
+func (*StringsSuite) TestHitCount(c *gc.C) {
+	cache := lru.NewStringCache(5)
+	cache.Intern("a")
+	cache.Intern("b")
+	cache.Intern("c")
+	cache.Intern("d")
+	cache.Intern("d")
+	cache.Intern("d")
+	cache.Intern("d")
+	c.Check(cache.HitCounts(), gc.Equals, lru.HitCounts{Hit: 3, Miss: 4})
+	cache.Intern("e")
+	cache.Intern("f")
+	cache.Intern("a")
+	// we overflowed, so everything misses
+	c.Check(cache.HitCounts(), gc.Equals, lru.HitCounts{Hit: 3, Miss: 7})
+}
+
 func (*StringsSuite) TestInternMultithreaded(c *gc.C) {
 	const totalKeys = 100000
 	const totalUniqueKeys = 1000


### PR DESCRIPTION
I looked into adding a mutex around Intern() but it seemed to cost about 10% CPU performance. It was a little hard to tell as the benchmark values weren't 100% stable.

Regardless this should address feedback from the previous PR and then add hit/miss counters. I added the counters because you can't see it from the outside, while you can always just wrap the call in a mutex.
