### PR TITLE
LRU using offsets vs pointers

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,86 +12,92 @@ import (
 	"github.com/juju/lru"
 )
 
-type BenchmarkSuite struct{}
+type BenchmarkLRUSuite struct{}
 
-var _ = gc.Suite(&BenchmarkSuite{})
+var _ = gc.Suite(&BenchmarkLRUSuite{})
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000010(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000010(c *gc.C) {
 	benchAddAndEvictInt(c, 10)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000020(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000020(c *gc.C) {
 	benchAddAndEvictInt(c, 20)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000050(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000050(c *gc.C) {
 	benchAddAndEvictInt(c, 50)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000100(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000100(c *gc.C) {
 	benchAddAndEvictInt(c, 100)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000200(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000200(c *gc.C) {
 	benchAddAndEvictInt(c, 200)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0000500(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0000500(c *gc.C) {
 	benchAddAndEvictInt(c, 500)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0001000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0001000(c *gc.C) {
 	benchAddAndEvictInt(c, 1000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0002000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0002000(c *gc.C) {
 	benchAddAndEvictInt(c, 2000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0005000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0005000(c *gc.C) {
 	benchAddAndEvictInt(c, 5000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0010000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0010000(c *gc.C) {
 	benchAddAndEvictInt(c, 10000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0020000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0020000(c *gc.C) {
 	benchAddAndEvictInt(c, 20000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0050000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0050000(c *gc.C) {
 	benchAddAndEvictInt(c, 50000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0100000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0100000(c *gc.C) {
 	benchAddAndEvictInt(c, 100000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0200000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0200000(c *gc.C) {
 	benchAddAndEvictInt(c, 200000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt0500000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt0500000(c *gc.C) {
 	benchAddAndEvictInt(c, 500000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt1000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt1000000(c *gc.C) {
 	benchAddAndEvictInt(c, 1000000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictInt2000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictInt2000000(c *gc.C) {
 	benchAddAndEvictInt(c, 2000000)
 }
 
-func (*BenchmarkSuite) BenchmarkIntMemSize(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkIntMemSize(c *gc.C) {
+	keys := make([]int, c.N)
+	for i := 0; i < c.N; i++ {
+		keys[i] = i + 1e7
+	}
+	c.ResetTimer()
+	rand.Shuffle(c.N, func(i, j int) { keys[j], keys[i] = keys[i], keys[j] })
 	cache := lru.New(c.N)
 	for i := 0; i < c.N; i++ {
-		cache.Add(i, i)
+		cache.Add(keys[i], i)
 	}
 }
 
-func (*BenchmarkSuite) BenchmarkStrMemSize(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkStrMemSize(c *gc.C) {
 	keys := make([]string, c.N)
 	for i := 0; i < c.N; i++ {
 		keys[i] = fmt.Sprint(i + 1e7)
@@ -122,71 +128,71 @@ func benchAddAndEvictInt(c *gc.C, size int) {
 	c.Assert(cache.Len(), gc.Equals, expectLen)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000010(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000010(c *gc.C) {
 	benchGet(c, 10)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000020(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000020(c *gc.C) {
 	benchGet(c, 20)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000050(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000050(c *gc.C) {
 	benchGet(c, 50)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000100(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000100(c *gc.C) {
 	benchGet(c, 100)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000200(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000200(c *gc.C) {
 	benchGet(c, 200)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0000500(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0000500(c *gc.C) {
 	benchGet(c, 500)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0001000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0001000(c *gc.C) {
 	benchGet(c, 1000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0002000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0002000(c *gc.C) {
 	benchGet(c, 2000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0005000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0005000(c *gc.C) {
 	benchGet(c, 5000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0010000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0010000(c *gc.C) {
 	benchGet(c, 10000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0020000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0020000(c *gc.C) {
 	benchGet(c, 20000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0050000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0050000(c *gc.C) {
 	benchGet(c, 50000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0100000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0100000(c *gc.C) {
 	benchGet(c, 100000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0200000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0200000(c *gc.C) {
 	benchGet(c, 200000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet0500000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet0500000(c *gc.C) {
 	benchGet(c, 500000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet1000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet1000000(c *gc.C) {
 	benchGet(c, 1000000)
 }
 
-func (*BenchmarkSuite) BenchmarkGet2000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkGet2000000(c *gc.C) {
 	benchGet(c, 2000000)
 }
 
@@ -205,71 +211,71 @@ func benchGet(c *gc.C, size int) {
 	}
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000010(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000010(c *gc.C) {
 	benchAddAndEvictStr(c, 10)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000020(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000020(c *gc.C) {
 	benchAddAndEvictStr(c, 20)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000050(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000050(c *gc.C) {
 	benchAddAndEvictStr(c, 50)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000100(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000100(c *gc.C) {
 	benchAddAndEvictStr(c, 100)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000200(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000200(c *gc.C) {
 	benchAddAndEvictStr(c, 200)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0000500(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0000500(c *gc.C) {
 	benchAddAndEvictStr(c, 500)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0001000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0001000(c *gc.C) {
 	benchAddAndEvictStr(c, 1000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0002000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0002000(c *gc.C) {
 	benchAddAndEvictStr(c, 2000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0005000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0005000(c *gc.C) {
 	benchAddAndEvictStr(c, 5000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0010000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0010000(c *gc.C) {
 	benchAddAndEvictStr(c, 10000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0020000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0020000(c *gc.C) {
 	benchAddAndEvictStr(c, 20000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0050000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0050000(c *gc.C) {
 	benchAddAndEvictStr(c, 50000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0100000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0100000(c *gc.C) {
 	benchAddAndEvictStr(c, 100000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0200000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0200000(c *gc.C) {
 	benchAddAndEvictStr(c, 200000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr0500000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr0500000(c *gc.C) {
 	benchAddAndEvictStr(c, 500000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr1000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr1000000(c *gc.C) {
 	benchAddAndEvictStr(c, 1000000)
 }
 
-func (*BenchmarkSuite) BenchmarkAddAndEvictStr2000000(c *gc.C) {
+func (*BenchmarkLRUSuite) BenchmarkAddAndEvictStr2000000(c *gc.C) {
 	benchAddAndEvictStr(c, 2000000)
 }
 

--- a/lru.go
+++ b/lru.go
@@ -6,70 +6,92 @@
 package lru
 
 import (
-	"container/list"
+	"fmt"
 )
+
+// maxLRUSize is the largest we can fit in a buffer with a 32-bit unsigned offset
+const maxLRUSize = (1<<32 - 1)
 
 // LRU implements a least-recently-used cache, evicting items from the cache if they have not been accessed in a while.
 type LRU struct {
-	maxSize int
-	keys    *list.List
-	values  map[interface{}]cacheEntry
+	size     int
+	maxSize  int
+	buf      []cacheEntry
+	elements map[interface{}]uint32
+	root     *cacheEntry
 }
 
 type cacheEntry struct {
-	listElem *list.Element
-	value    interface{}
+	prev, next uint32
+	key        interface{}
+	value      interface{}
 }
 
 // Create a new LRU cache that will hold no more than the given number of items,
 func New(size int) *LRU {
-	return &LRU{
-		maxSize: size,
-		keys:    list.New(),
-		values:  make(map[interface{}]cacheEntry, 0),
+	if size > maxLRUSize || size <= 0 {
+		panic("size must not be <= 0 or >= 2^32")
 	}
+	initialBufSize := size + 1
+	if initialBufSize > 100 {
+		initialBufSize = 101
+	}
+	lru := &LRU{
+		size:    0,
+		maxSize: size,
+		// TODO: dynamically allocate the size array
+		buf:      make([]cacheEntry, initialBufSize),
+		elements: make(map[interface{}]uint32, initialBufSize),
+	}
+	lru.root = &lru.buf[0]
+	return lru
 }
 
 // Len gives the number of items in the cache
 func (lru *LRU) Len() int {
-	return len(lru.values)
+	return lru.size
 }
 
 // Add a new entry into the LRU cache
 func (lru *LRU) Add(key, value interface{}) {
-	entry, exists := lru.values[key]
+	elem, exists := lru.elements[key]
 	if exists {
-		lru.keys.MoveToFront(entry.listElem)
+		entry := &lru.buf[elem]
+		lru.moveToFront(elem, entry)
 		// Update the value
 		entry.value = value
 	} else {
 		// We are adding an element, make sure there is room
-		var elem *list.Element
-		if lru.keys.Len() >= lru.maxSize {
-			elem = lru.keys.Back()
-			if elem != nil {
-				delete(lru.values, elem.Value)
-				elem.Value = key
-				lru.keys.MoveToFront(elem)
+		if lru.size < lru.maxSize {
+			// grab the next element
+			lru.size++
+			elem = uint32(lru.size)
+			if lru.size >= len(lru.buf) {
+				lru.realloc()
 			}
+		} else {
+			// reuse the least recently used element
+			elem = lru.root.prev
+			delete(lru.elements, lru.buf[elem].key)
 		}
-		if elem == nil {
-			elem = lru.keys.PushFront(key)
+		if elem >= uint32(len(lru.buf)) {
+			panic(fmt.Sprintf("element %d outside of buffer range: %d", elem, len(lru.buf)))
 		}
-		entry = cacheEntry{
-			listElem: elem,
-			value:    value,
-		}
+		entry := &lru.buf[elem]
+		entry.key = key
+		entry.value = value
+		lru.elements[key] = elem
+		lru.moveToFront(elem, entry)
 	}
-	lru.values[key] = entry
 }
 
 // Get returns the Value associated with key, and a boolean as to whether it actually exists in the cache.
 // If it does exist in the cache, then it is treated as recently accessed.
 func (lru *LRU) Get(key interface{}) (interface{}, bool) {
-	entry, exists := lru.values[key]
+	elem, exists := lru.elements[key]
 	if exists {
-		lru.keys.MoveToFront(entry.listElem)
+		entry := &lru.buf[elem]
+		lru.moveToFront(elem, entry)
 		return entry.value, true
 	} else {
 		return nil, false
@@ -78,8 +100,48 @@ func (lru *LRU) Get(key interface{}) (interface{}, bool) {
 
 // Peek is just like Get() except it doesn't affect if it was 'recently accessed'
 func (lru *LRU) Peek(key interface{}) (interface{}, bool) {
-	if entry, exists := lru.values[key]; exists {
-		return entry.value, true
+	if elem, exists := lru.elements[key]; exists {
+		return lru.buf[elem].value, true
 	}
 	return nil, false
+}
+
+func (lru *LRU) realloc() {
+	// We save 1 slot at the beginning for root, this makes 'offset = 0' an invalid value
+	// which makes debugging much easier, and we need start and end pointers anyway.
+	nextSize := (len(lru.buf) - 1) * 2
+	if nextSize > lru.maxSize {
+		nextSize = lru.maxSize
+	}
+	newBuf := make([]cacheEntry, nextSize+1)
+	copy(newBuf, lru.buf)
+	lru.buf = newBuf
+	lru.root = &newBuf[0]
+	if nextSize == lru.maxSize {
+		// We let the map grow using normal go growth, but when we hit maxSize,
+		// we know that we won't ever hold more entries than that, so we don't
+		// want to have it grow arbitrarily larger.
+		elements := make(map[interface{}]uint32, nextSize)
+		for k, v := range lru.elements {
+			elements[k] = v
+		}
+		lru.elements = elements
+	}
+}
+
+func (lru *LRU) moveToFront(elem uint32, entry *cacheEntry) {
+	if lru.root.next == elem {
+		// we're already at the front
+		return
+	}
+	if entry.prev != 0 {
+		// remove it from its current spot
+		lru.buf[entry.prev].next = entry.next
+		lru.buf[entry.next].prev = entry.prev
+	}
+	next := lru.root.next
+	entry.prev = 0
+	entry.next = next
+	lru.root.next = elem
+	lru.buf[next].prev = elem
 }

--- a/lru.go
+++ b/lru.go
@@ -37,9 +37,8 @@ func New(size int) *LRU {
 		initialBufSize = 101
 	}
 	lru := &LRU{
-		size:    0,
-		maxSize: size,
-		// TODO: dynamically allocate the size array
+		size:     0,
+		maxSize:  size,
 		buf:      make([]cacheEntry, initialBufSize),
 		elements: make(map[interface{}]uint32, initialBufSize),
 	}
@@ -71,6 +70,9 @@ func (lru *LRU) Add(key, value interface{}) {
 			}
 		} else {
 			// reuse the least recently used element
+			// Note: if we ever support Remove(), we can keep the 'removed'
+			// items on a separate linked list of locations that are available.
+			// Still allowing us to avoid allocating/freeing records frequently.
 			elem = lru.root.prev
 			delete(lru.elements, lru.buf[elem].key)
 		}

--- a/lru_test.go
+++ b/lru_test.go
@@ -56,6 +56,14 @@ func simpleFullCache() *lru.LRU {
 	return cache
 }
 
+func (s *LRUSuite) TestLRUOne(c *gc.C) {
+	cache := lru.New(1)
+	cache.Add(1, "a")
+	cache.Add(2, "b")
+	checkPeekMissing(c, cache, 1)
+	checkPeekExists(c, cache, 2, "b")
+}
+
 func (s *LRUSuite) TestLRUAdd(c *gc.C) {
 	cache := lru.New(128)
 	cache.Add("foo", "bar")

--- a/strings.go
+++ b/strings.go
@@ -136,7 +136,7 @@ func (sc *StringCache) realloc(nextSize int) {
 	if nextSize == 0 {
 		// We save 1 slot at the beginning for root, this makes 'offset = 0' an invalid value
 		// which makes debugging much easier, and we need start and end pointers anyway.
-		nextSize = (len(sc.buf) - 1) * 3
+		nextSize = (len(sc.buf) - 1) * 2
 		if nextSize > sc.maxSize {
 			nextSize = sc.maxSize
 		}
@@ -204,7 +204,8 @@ func (sc *StringCache) moveToFront(elem uint32) {
 }
 
 // Prealloc allocates a maxSize buffer immediately, rather than slowly growing
-// the buffer to maxSize.
+// the buffer to maxSize. If you know that you need the full buffer size, this
+// can make initial loading of the buffer 2-3x faster.
 func (sc *StringCache) Prealloc() {
 	values := make(map[string]uint32, sc.maxSize)
 	for k, v := range sc.values {

--- a/strings.go
+++ b/strings.go
@@ -22,15 +22,22 @@ type StringCache struct {
 	size      int
 	hitCount  int64
 	missCount int64
-	root      stringElem
-	values    map[string]*stringElem
+	buf       []stringElem
+	values    map[string]uint32
+	root      *stringElem
 }
+
+const invalidElem = uint32((1 << 32) - 1)
 
 // NewStringCache creates a cache for string objects that will hold no-more
 // than 'size' strings.
 func NewStringCache(size int) *StringCache {
 	cache := &StringCache{
 		maxSize: size,
+	}
+	if size > 1<<32 {
+		// maxSize cannot be > 2**32
+		panic("cannot set maxSize bigger than an unsigned 32bit integer")
 	}
 	cache.init()
 	return cache
@@ -46,14 +53,17 @@ func NewStringCache(size int) *StringCache {
 // instead replacing the content when the old value is expired.
 type stringElem struct {
 	value      string
-	prev, next *stringElem
+	prev, next uint32
 }
 
 func (sc *StringCache) init() {
-	sc.values = make(map[string]*stringElem, sc.maxSize)
-	sc.root.prev = &sc.root
-	sc.root.next = &sc.root
+	sc.values = make(map[string]uint32, sc.maxSize)
+	// TODO: (jam) do dynamic allocation rather than preallocating max size
+	sc.buf = make([]stringElem, sc.maxSize+1)
 	sc.size = 0
+	sc.root = &sc.buf[0]
+	sc.root.next = 0
+	sc.root.prev = 0
 }
 
 // Len returns how many strings are currently cached
@@ -75,46 +85,39 @@ func (sc *StringCache) HitCounts() HitCounts {
 	}
 }
 
-// realloc creates a slice of memory, and puts everything in order and
-// simplifies the pointers.  This allocates into a single slab of memory,
-// instead of being scattered around everywhere. We call this once our cache is
-// full, and we know we won't be allocating any more elements.
-func (sc *StringCache) realloc() {
-	buff := make([]stringElem, sc.maxSize)
-	cur := sc.root.next
-	for i := 0; i < sc.maxSize; i++ {
-		buff[i].value = cur.value
-		if i > 0 {
-			buff[i].prev = &buff[i-1]
-		}
-		if i < sc.maxSize-1 {
-			buff[i].next = &buff[i+1]
-		}
-		sc.values[cur.value] = &buff[i]
-		cur = cur.next
-	}
-	sc.root.next = &buff[0]
-	sc.root.prev = &buff[sc.maxSize-1]
-	buff[0].prev = &sc.root
-	buff[sc.maxSize-1].next = &sc.root
-}
-
 // Validate checks invariants to make sure the double-linked list is properly
 // linked, and that the values map to the correct element.
 func (sc *StringCache) Validate() error {
 	count := 0
-	for cur := sc.root.next; cur != &sc.root; cur = cur.next {
+	if sc.root != &sc.buf[0] {
+		return fmt.Errorf("error, root=%p, not buf[0]=%p", sc.root, &sc.buf[0])
+	}
+	for cur := sc.root.next; cur != 0; cur = sc.buf[cur].next {
 		count++
-		if cur.prev.next != cur {
-			return fmt.Errorf("error at %#v, the value after prev is not this", cur)
+		curS := &sc.buf[cur]
+		if curS.prev > uint32(len(sc.buf)) {
+			return fmt.Errorf("error at %#v, the value prev %d > len(buf) %d", curS, curS.prev, len(sc.buf))
 		}
-		if cur.next.prev != cur {
-			return fmt.Errorf("error at %#v, the value before next is not this", cur)
+		prev := &sc.buf[curS.prev]
+		if prev.next != cur {
+			return fmt.Errorf("error at %#v, the prev.next (%d) is not this %d", curS, prev.next, cur)
 		}
-		v := cur.value
+		if curS.next > uint32(len(sc.buf)) {
+			return fmt.Errorf("error at %#v, the value next %d > len(buf) %d", curS, curS.next, len(sc.buf))
+		}
+		next := &sc.buf[curS.next]
+		if next.prev != cur {
+			return fmt.Errorf("error at %#v, the next.prev (%d) is not this %d", curS, next.prev, cur)
+		}
+		v := curS.value
 		if sc.values[v] != cur {
-			return fmt.Errorf("error at %q, %p %# v, the map doesn't point to cur it points to: %p %# v",
-				v, cur, cur, sc.values[v], sc.values[v])
+			if sc.values[v] > uint32(len(sc.buf)) {
+				return fmt.Errorf("error at %q, %d %# v, the map doesn't point to cur it points to: %d (outside of buf)",
+					v, cur, curS, sc.values[v])
+			} else {
+				return fmt.Errorf("error at %q, %d %# v, the map doesn't point to cur it points to: %d %# v",
+					v, cur, curS, sc.values[v], sc.buf[sc.values[v]])
+			}
 		}
 	}
 	if count != sc.size {
@@ -132,24 +135,21 @@ func (sc *StringCache) Validate() error {
 func (sc *StringCache) Intern(v string) string {
 	if elem, ok := sc.values[v]; ok {
 		sc.moveToFront(elem)
-		v := elem.value
+		value := sc.buf[elem].value
 		sc.hitCount++
-		return v
+		return value
 	}
 	sc.missCount++
-	var elem *stringElem
+	var elem uint32
 	if sc.size < sc.maxSize {
-		elem = &stringElem{value: v}
 		sc.size++
-		if sc.size == sc.maxSize {
-			sc.moveToFront(elem)
-			sc.realloc()
-			return v
-		}
+		elem = uint32(sc.size)
+		sc.buf[elem].value = v
 	} else {
 		elem = sc.root.prev
-		delete(sc.values, elem.value)
-		elem.value = v
+		e := &sc.buf[elem]
+		delete(sc.values, e.value)
+		e.value = v
 	}
 	sc.moveToFront(elem)
 	sc.values[v] = elem
@@ -163,19 +163,20 @@ func (sc *StringCache) Contains(v string) bool {
 	return ok
 }
 
-func (sc *StringCache) moveToFront(elem *stringElem) {
+func (sc *StringCache) moveToFront(elem uint32) {
 	if sc.root.next == elem {
 		// we're already at the front
 		return
 	}
-	if elem.prev != nil {
+	e := &sc.buf[elem]
+	if e.prev != 0 {
 		// remove it from its current spot
-		elem.prev.next = elem.next
-		elem.next.prev = elem.prev
+		sc.buf[e.prev].next = e.next
+		sc.buf[e.next].prev = e.prev
 	}
 	next := sc.root.next
+	e.prev = 0
+	e.next = next
 	sc.root.next = elem
-	elem.prev = &sc.root
-	elem.next = next
-	next.prev = elem
+	sc.buf[next].prev = elem
 }

--- a/strings.go
+++ b/strings.go
@@ -27,17 +27,14 @@ type StringCache struct {
 	root      *stringElem
 }
 
-const invalidElem = uint32((1 << 32) - 1)
-
 // NewStringCache creates a cache for string objects that will hold no-more
 // than 'size' strings.
 func NewStringCache(size int) *StringCache {
+	if size > maxLRUSize || size <= 0 {
+		panic("size must not be <= 0 or >= 2^32")
+	}
 	cache := &StringCache{
 		maxSize: size,
-	}
-	if size > 1<<32 {
-		// maxSize cannot be > 2**32
-		panic("cannot set maxSize bigger than an unsigned 32bit integer")
 	}
 	cache.init()
 	return cache

--- a/strings_test.go
+++ b/strings_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Canonical Ltd.
+// Copyright 2019 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package lru_test
@@ -38,10 +38,12 @@ func (*StringsSuite) TestIntern(c *gc.C) {
 	str2 := fmt.Sprintf("foo%s", "bar")
 	c.Check(isSameStr(str1, str2), gc.Equals, false)
 
-	cache := lru.NewStringCache(100)
+	cache := lru.NewStringCache(10)
 	str3 := cache.Intern(str1)
+	c.Assert(cache.Validate(), gc.IsNil)
 	c.Check(isSameStr(str1, str3), gc.Equals, true)
 	str4 := cache.Intern(str2)
+	c.Assert(cache.Validate(), gc.IsNil)
 	c.Check(isSameStr(str1, str4), gc.Equals, true)
 	c.Check(cache.Len(), gc.Equals, 1)
 	c.Check(cache.Contains(str1), gc.Equals, true)
@@ -86,6 +88,7 @@ func (*StringsSuite) TestInternAbuse(c *gc.C) {
 		c.Assert(v, gc.Equals, k)
 	}
 	c.Check(cache.Len(), gc.Equals, size)
+	c.Assert(cache.Validate(), gc.IsNil)
 }
 
 func (*StringsSuite) TestHitCount(c *gc.C) {
@@ -103,6 +106,7 @@ func (*StringsSuite) TestHitCount(c *gc.C) {
 	cache.Intern("a")
 	// we overflowed, so everything misses
 	c.Check(cache.HitCounts(), gc.Equals, lru.HitCounts{Hit: 3, Miss: 7})
+	c.Assert(cache.Validate(), gc.IsNil)
 }
 
 func (*StringsSuite) TestInternMultithreaded(c *gc.C) {
@@ -140,6 +144,7 @@ func (*StringsSuite) TestInternMultithreaded(c *gc.C) {
 	hitCount := cache.HitCounts()
 	c.Logf("hit count: %# v", hitCount)
 	c.Check(hitCount.Hit+hitCount.Miss, gc.Equals, int64(totalKeys*threads))
+	c.Assert(cache.Validate(), gc.IsNil)
 }
 
 var _ = gc.Suite(&BenchmarkStrings{})


### PR DESCRIPTION
This changes the LRU implementations from using pointers and list.List entries to using offsets into a buffer.

The big wins here are in total memory consumption and memory fragmentation. Benchmarks show that it is a fair bit faster, and a lot less memory churn.
https://docs.google.com/spreadsheets/d/1dKU65ctSM7wll5BABmK6RNhyiPRDdqFg5ofjiJLYBoE/edit?usp=sharing

![Benchmarks](https://user-images.githubusercontent.com/202877/54208671-c720c280-44f5-11e9-9e7d-ada1040af26d.png)

I created a script that used the various LRU implementations to cache "Count" 8-byte keys, and then asked go runtime to tell me things like how long it took and how much memory was being consumed.
There were 2 main tests:

1. Inserting 1M,2M,5M,10M keys into a cache with 1M slots. This tests just insert performance when things are being excised as fast as they are being inserted. It also tests total memory consumption.
2. Creating a cache of size 1/2/5/10M and then inserting twice as many keys. This tests how memory scales when you have a larger cache.

Some interesting datapoints from the benchmarking

- Prealloc has a larger effect across the board than I expected. I had thought that things like inserting 10x the keys into a 1M buffer would result in the time not mattering (the buffer fills after the first 1M keys, and from then on the rest of the inserts don't reallocate memory). It is plausible that this is just the initial offset, as the slow doesn't seem dramatically affected. (it adds about 300ms to not prealloc but the test itself finishes in about 900ms worst case).

- TotalAlloc of Intern (old and new) and the new LRU are way better than previous, and better than Hashicorps implementation. At small numbers, Hashicorp never reallocs, so 1M into 1M cache looks better. But Juju *doesn't* allocate on every Add() which scales much better.

- Final HeapInUse is a bit noisy, I think this is dependent on how we trigger GC, as it seems surprising that 5M keys into a 1M cache, would use more memory than 10M keys into a 1M cache. The big win for HeapInUse is Prealloc, and the new LRU implementation that uses a fixed buffer, instead of a `list.List` and a map to `*list.Element`. "master lru" had better time performance on large number of keys, because it avoided one of the dereference operations (simplelru points at a list.Element, and then has to get to list.Element.Values.value.) Also the extra alloc for every new Add() having to create an 'element' struct to put in the Values interface. However, master lru used quite a bit more memory, because its 'complex' struct was saved in the map, which means that the empty slots the map preallocates were large, rather than just a simple pointer. The new implementation uses a uint32 and then the large structs are just stored in a compact array.

- For the use case of caching strings, Intern dominates all the LRU implementations (memory, speed, etc). Probably because it doesn't indirect via interface{}? And it certainly can have fewer pointers overall (doesn't need a key pointer, etc.)

- The fixed size buffer is both faster and consumes less memory, which is nice. I had been worried that updating the linked list would be faster with pointers, but I suppose if you have to page in a different set of memory, it is the same cost, and this way the memory is more compact, so there is less overall paging.

- Prealloc is so much faster, I might just make it the standard behavior and remove dynamic memory allocation. If you size the cache correctly, it will all be in use anyway.

- The new code does allocate more total memory if you *don't* prealloc, then the old code did for Intern. This may be a case of 'realloc()' needing more memory for a brief period of time, and golang maps being more efficient at growing organically. But with prealloc, we improve that dramatically.
